### PR TITLE
fix regression, consistent lib directory

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,7 +7,7 @@ cmake .. -G "Ninja" \
       -DNG_INSTALL_DIR_INCLUDE=$PREFIX/include/netgen \
       -DNG_INSTALL_DIR_PYTHON=${SP_DIR} \
       -DNG_INSTALL_DIR_BIN=bin \
-      -DNG_INSTALL_DIR_LIB=lib/netgen \
+      -DNG_INSTALL_DIR_LIB=lib \
       -DNG_INSTALL_DIR_CMAKE=lib/cmake/netgen \
       -DNG_INSTALL_DIR_RES=share \
       -DOCC_INCLUDE_DIR=$PREFIX/include/opencascade \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
         - salome.patch
 
 build:
-    number: 1
+    number: 2
     features:
         - vc14  # [win]
     skip: true  # [py<35 or win32]


### PR DESCRIPTION
@conda-forge/core can someone set the previous builds to broken.
After testing it looks like osx and linux used a wrong lib-directory.


the checked builds should be set to broken:
osx/ linux  netgen-6.2.1802-py36_1.tar.bz2 & netgen-6.2.1802-py35_1.tar.bz2
![grafik](https://user-images.githubusercontent.com/5084704/39053509-79352486-44af-11e8-9be8-53d734ac1210.png)

