### PR TITLE
Add CMAKE_POLICY_VERSION_MINIMUM=3.5 to CMake.

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -2,6 +2,7 @@ mkdir build
 cd build
 
 cmake -G "Ninja" ^
+      -D CMAKE_POLICY_VERSION_MINIMUM=3.5 ^
       -D CMAKE_BUILD_TYPE:STRING="Release" ^
       -D CMAKE_PREFIX_PATH:FILEPATH="%PREFIX%" ^
       -D CMAKE_INSTALL_PREFIX:FILEPATH="%LIBRARY_PREFIX%" ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,6 +3,7 @@ cd build
 
 
 cmake -G "Ninja" \
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
       -D CMAKE_BUILD_TYPE=Release \
       -D CMAKE_INSTALL_PREFIX:FILEPATH=$PREFIX \
       -D CMAKE_PREFIX_PATH:FILEPATH=$PREFIX \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - cmake.patch
 
 build:
-  number: 4
+  number: 5
   skip: true  # [py27]
 
 requirements:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Add CMAKE_POLICY_VERSION_MINIMUM=3.5 to CMake command line for compatibility with CMake 4.