### PR TITLE
add patch to fix egg-info filename

### DIFF
--- a/recipe/patches/fix-egg-info-name.patch
+++ b/recipe/patches/fix-egg-info-name.patch
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -692,14 +692,14 @@
+ endif(UNIX)
+ 
+ if(USE_PYTHON AND NOT SKBUILD)
+   # install egg file to let python/pip know that Netgen ist installed
+-  file( WRITE "netgen_mesher-py3.egg-info"
++  file( WRITE "netgen_mesher-${NETGEN_VERSION_MAJOR}.${NETGEN_VERSION_MINOR}.${NETGEN_VERSION_PATCH}.post${NETGEN_VERSION_TWEAK}.egg-info"
+ "Metadata-Version: 2.1
+ Name: netgen-mesher
+ Version: ${NETGEN_VERSION_MAJOR}.${NETGEN_VERSION_MINOR}.${NETGEN_VERSION_PATCH}.post${NETGEN_VERSION_TWEAK}
+ ")
+-  install(FILES netgen_mesher-py3.egg-info DESTINATION ${NG_INSTALL_DIR_PYTHON} COMPONENT netgen)
++  install(FILES netgen_mesher-${NETGEN_VERSION_MAJOR}.${NETGEN_VERSION_MINOR}.${NETGEN_VERSION_PATCH}.post${NETGEN_VERSION_TWEAK}.egg-info DESTINATION ${NG_INSTALL_DIR_PYTHON} COMPONENT netgen)
+ endif()
+ 
+ if(APPLE AND NOT SKBUILD)
+     # create some auxiliary files

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -16,7 +16,7 @@ source:
     - patches/fix-egg-info-name.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -12,6 +12,8 @@ package:
 source:
   url: https://github.com/looooo/netgen/archive/refs/tags/v${{ version }}.tar.gz
   sha256: ${{ sha256 }}
+  patches:
+    - patches/fix-egg-info-name.patch
 
 build:
   number: 0


### PR DESCRIPTION
as mentioned in https://github.com/conda-forge/netgen-feedstock/pull/58#issuecomment-4226099307 the package currently makes pixi fail because the egg-info file does not have the expected name format

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
